### PR TITLE
[BE] 열린 이슈, 닫힌 이슈 조회 기능 구현 #3

### DIFF
--- a/src/main/java/codesquad/issuetracker/issue/Issue.java
+++ b/src/main/java/codesquad/issuetracker/issue/Issue.java
@@ -1,6 +1,8 @@
 package codesquad.issuetracker.issue;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -8,6 +10,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.PersistenceCreator;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.domain.Persistable;
+import org.springframework.data.relational.core.mapping.MappedCollection;
 
 @Getter
 @ToString
@@ -18,12 +21,14 @@ public class Issue implements Persistable<Long> {
     private String authorId;
     private String title;
     private String description;
-    private LocalDateTime createdAt;
+    private LocalDateTime openAt;
     private LocalDateTime updatedAt;
     private LocalDateTime closedAt;
     private Long milestoneId;
     private boolean isOpen;
     private boolean isDeleted;
+    @MappedCollection(idColumn = "ISSUE_ID")
+    private Set<LabelRef> labelRefs = new HashSet<>();
     @Transient
     private boolean isNew;
 
@@ -35,26 +40,27 @@ public class Issue implements Persistable<Long> {
     @Builder
     @PersistenceCreator
     public Issue(Long id, String authorId, String title, String description,
-        LocalDateTime createdAt,
+        LocalDateTime openAt,
         LocalDateTime updatedAt, LocalDateTime closedAt, Long milestoneId, boolean isOpen,
-        boolean isDeleted) {
+        boolean isDeleted, Set<LabelRef> labelRefs) {
         this.id = id;
         this.authorId = authorId;
         this.title = title;
         this.description = description;
-        this.createdAt = createdAt;
+        this.openAt = openAt;
         this.updatedAt = updatedAt;
         this.closedAt = closedAt;
         this.milestoneId = milestoneId;
         this.isOpen = isOpen;
         this.isDeleted = isDeleted;
+        this.labelRefs = labelRefs;
         this.isNew = false;
     }
 
-    public static Issue from(Long id, String authorId, String title, String description, Long milestoneId,
-        boolean isOpen) {
+    public static Issue from(Long id, String authorId, String title, String description,
+        Long milestoneId, Set<LabelRef> labelRefs) {
         Issue issue = new Issue(id, authorId, title, description, LocalDateTime.now(),
-            LocalDateTime.now(), LocalDateTime.now(), milestoneId, isOpen, false);
+            LocalDateTime.now(), LocalDateTime.now(), milestoneId, true, false, labelRefs);
         issue.isNew = true;
         return issue;
     }

--- a/src/main/java/codesquad/issuetracker/issue/IssueController.java
+++ b/src/main/java/codesquad/issuetracker/issue/IssueController.java
@@ -1,0 +1,24 @@
+package codesquad.issuetracker.issue;
+
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/issues")
+public class IssueController {
+
+    IssueService issueService;
+
+    public IssueController(IssueService issueService) {
+        this.issueService = issueService;
+    }
+
+    @GetMapping
+    public List<Issue> getIssues(@RequestParam boolean isOpen) {
+        return issueService.findIssuesByIsOpen(isOpen);
+    }
+
+}

--- a/src/main/java/codesquad/issuetracker/issue/IssueRepository.java
+++ b/src/main/java/codesquad/issuetracker/issue/IssueRepository.java
@@ -1,0 +1,12 @@
+package codesquad.issuetracker.issue;
+
+import java.util.List;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IssueRepository extends CrudRepository<Issue, Long> {
+
+    List<Issue> findAllByIsOpen(boolean isOpen);
+
+}

--- a/src/main/java/codesquad/issuetracker/issue/IssueService.java
+++ b/src/main/java/codesquad/issuetracker/issue/IssueService.java
@@ -1,0 +1,25 @@
+package codesquad.issuetracker.issue;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class IssueService {
+
+    IssueRepository issueRepository;
+
+    @Autowired
+    public IssueService(IssueRepository issueRepository) {
+        this.issueRepository = issueRepository;
+    }
+
+    public List<Issue> findIssuesByIsOpen(boolean isOpen) {
+        return issueRepository.findAllByIsOpen(isOpen);
+    }
+
+    public List<Issue> findAllIssues() {
+        return (List<Issue>) issueRepository.findAll();
+    }
+
+}

--- a/src/main/java/codesquad/issuetracker/issue/LabelRef.java
+++ b/src/main/java/codesquad/issuetracker/issue/LabelRef.java
@@ -1,0 +1,14 @@
+package codesquad.issuetracker.issue;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Getter
+@RequiredArgsConstructor
+@Table("ISSUE_LABEL")
+public class LabelRef {
+
+    private final Long labelId;
+
+}

--- a/src/test/java/codesquad/issuetracker/issue/IssueControllerTest.java
+++ b/src/test/java/codesquad/issuetracker/issue/IssueControllerTest.java
@@ -42,11 +42,9 @@ class IssueControllerTest {
 
         List<Issue> openIssues = List.of(issue1, issue2);
         List<Issue> closedIssues = List.of(issue3, issue4);
-        List<Issue> allIssues = List.of(issue1, issue2, issue3, issue4);
 
         when(issueService.findIssuesByIsOpen(true)).thenReturn(openIssues);
         when(issueService.findIssuesByIsOpen(false)).thenReturn(closedIssues);
-        when(issueService.findAllIssues()).thenReturn(allIssues);
     }
 
     @Test
@@ -62,16 +60,9 @@ class IssueControllerTest {
     @DisplayName("닫힌 이슈 목록을 가져올 수 있다.")
     void getClosedIssues() throws Exception {
 
-        mockMvc.perform(get("/api/issues?isOpen=false"))
+        mockMvc.perform(get("/api/issues"))
             .andExpect(jsonPath("$[0].open").value(false))
             .andExpect(jsonPath("$[1].open").value(false));
     }
 
-    @Test
-    @DisplayName("모든 이슈 목록을 가져올 수 있다.")
-    void getAllIssues() throws Exception {
-
-        mockMvc.perform(get("/api/issues?isOpen=false"))
-            .andExpect(jsonPath("$.length()").value(4));
-    }
 }

--- a/src/test/java/codesquad/issuetracker/issue/IssueControllerTest.java
+++ b/src/test/java/codesquad/issuetracker/issue/IssueControllerTest.java
@@ -1,0 +1,77 @@
+package codesquad.issuetracker.issue;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(IssueController.class)
+class IssueControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @MockBean
+    IssueService issueService;
+
+    @BeforeEach
+    void init() {
+        Issue issue1 = Issue.builder()
+            .id(1L)
+            .isOpen(true)
+            .build();
+        Issue issue2 = Issue.builder()
+            .id(2L)
+            .isOpen(true)
+            .build();
+        Issue issue3 = Issue.builder()
+            .id(3L)
+            .isOpen(false)
+            .build();
+        Issue issue4 = Issue.builder()
+            .id(4L)
+            .isOpen(false)
+            .build();
+
+        List<Issue> openIssues = List.of(issue1, issue2);
+        List<Issue> closedIssues = List.of(issue3, issue4);
+        List<Issue> allIssues = List.of(issue1, issue2, issue3, issue4);
+
+        when(issueService.findIssuesByIsOpen(true)).thenReturn(openIssues);
+        when(issueService.findIssuesByIsOpen(false)).thenReturn(closedIssues);
+        when(issueService.findAllIssues()).thenReturn(allIssues);
+    }
+
+    @Test
+    @DisplayName("열린 이슈 목록을 가져올 수 있다.")
+    void getOpenIssues() throws Exception {
+
+        mockMvc.perform(get("/api/issues?isOpen=true"))
+            .andExpect(jsonPath("$[0].open").value(true))
+            .andExpect(jsonPath("$[1].open").value(true));
+    }
+
+    @Test
+    @DisplayName("닫힌 이슈 목록을 가져올 수 있다.")
+    void getClosedIssues() throws Exception {
+
+        mockMvc.perform(get("/api/issues?isOpen=false"))
+            .andExpect(jsonPath("$[0].open").value(false))
+            .andExpect(jsonPath("$[1].open").value(false));
+    }
+
+    @Test
+    @DisplayName("모든 이슈 목록을 가져올 수 있다.")
+    void getAllIssues() throws Exception {
+
+        mockMvc.perform(get("/api/issues?isOpen=false"))
+            .andExpect(jsonPath("$.length()").value(4));
+    }
+}

--- a/src/test/java/codesquad/issuetracker/issue/IssueRepositoryTest.java
+++ b/src/test/java/codesquad/issuetracker/issue/IssueRepositoryTest.java
@@ -1,0 +1,60 @@
+package codesquad.issuetracker.issue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import codesquad.issuetracker.user.User;
+import codesquad.issuetracker.user.UserRepository;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
+import org.springframework.test.context.jdbc.Sql;
+
+@DataJdbcTest
+@Slf4j
+class IssueRepositoryTest {
+
+    @Autowired
+    IssueRepository issueRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @BeforeEach
+    void init() {
+        User user = User.from("cori1234", "cori", "123");
+        userRepository.save(user);
+    }
+
+    @Test
+    @DisplayName("열린 이슈 목록 가져오기")
+    void getOpenIssues() {
+
+        Issue issue1 = Issue.from(1L, "cori1234", "제목", "내용", 1L, new HashSet<>());
+        Issue issue2 = Issue.from(2L, "cori1234", "제목2", "내용2",2L, new HashSet<>());
+        Issue issue3 = Issue.from(3L, "cori1234","제목3", "내용3",3L, new HashSet<>());
+
+        issueRepository.save(issue1);
+        issueRepository.save(issue2);
+        issueRepository.save(issue3);
+
+        List<Issue> openIssues = issueRepository.findAllByIsOpen(true);
+
+        assertThat(openIssues).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("이슈를 만들고 저장소에 저장하는 테스트")
+    void testCreateAndSaveIssue() {
+
+        Issue issue = Issue.from(1L, "cori1234", "제목", "내용", 1L, new HashSet<>());
+        Issue savedIssued = issueRepository.save(issue);
+
+        assertThat(savedIssued).usingRecursiveComparison().isEqualTo(issue);
+    }
+}

--- a/src/test/java/codesquad/issuetracker/issue/IssueRepositoryTest.java
+++ b/src/test/java/codesquad/issuetracker/issue/IssueRepositoryTest.java
@@ -57,4 +57,16 @@ class IssueRepositoryTest {
 
         assertThat(savedIssued).usingRecursiveComparison().isEqualTo(issue);
     }
+
+    @Test
+    @DisplayName("레이블 레퍼런스를 가져올 수 있다.")
+    @Sql("/sql/label-data.sql")
+    void findLabels() {
+        Set<LabelRef> labelRefs = Set.of(new LabelRef(1L), new LabelRef(2L), new LabelRef(3L));
+        Issue issue = Issue.from(1L, "cori1234", "제목", "내용", 1L, labelRefs);
+        Issue savedIssued = issueRepository.save(issue);
+
+        log.info("labels = {}", savedIssued.getLabelRefs());
+
+    }
 }


### PR DESCRIPTION
- 제목 : [BE] feat(issue 번호): 기능명

## 🔘Part
- [x] BE

  <br/>

## 🔎 작업 내용
- `GET` `/api/issues?isOpen=true` 으로 요청이 들어오면 열린 이슈 목록 반환
- `GET` `/api/issues?isOpen=false` 으로 요청이 들어오면 닫힌 이슈 목록 반환
- `ISSUE` 테이블과 `LABEL` 테이블의 N:M 관계
-  `labelId`를 필드로 가지는 `LabelRef` 클래스 정의
- `Issue` 객체가 연관 관계에 있는 `Label`을 가져올 수 있도록 `Issue` 클래스는 `Set<LabelRef>`를 필드로 가진다

  <br/>


<br/>
