### PR TITLE
[BE] 마일스톤이 null일 때 발생하는 오류 해결

### DIFF
--- a/BE/issue-tracker/src/main/java/codesquad/issuetracker/issue/Issue.java
+++ b/BE/issue-tracker/src/main/java/codesquad/issuetracker/issue/Issue.java
@@ -67,7 +67,8 @@ public class Issue {
     }
 
     public static Issue of(String authorId, String title, String content,
-        AggregateReference<Milestone, Long> milestoneId, Set<IssueAttachedLabel> labelRefs, Set<Assignee> assignees) {
+        AggregateReference<Milestone, Long> milestoneId, Set<IssueAttachedLabel> labelRefs,
+        Set<Assignee> assignees) {
         return Issue.builder()
             .authorId(authorId)
             .title(title)
@@ -93,10 +94,9 @@ public class Issue {
         comments.forEach(Comment::delete);
     }
 
-    public Long getMilestoneId() {
+    public Optional<Long> getMilestoneId() {
         return Optional.ofNullable(milestoneId)
-            .map(AggregateReference::getId)
-            .orElse(null);
+            .map(AggregateReference::getId);
     }
 
     public void updateLabels(List<Long> labels) {
@@ -112,7 +112,7 @@ public class Issue {
     }
 
     public void updateMilestone(Long milestoneId) {
-        this.milestoneId = AggregateReference.to(milestoneId);
+        this.milestoneId = milestoneId == null ? null : AggregateReference.to(milestoneId);
     }
 
     public void changeState(State state) {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 구현
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] BE
- [ ] FE
  
### 반영 브랜치
ex) hotfix/handle-null-milestone -> dev-be

### 🔎 작업 내용
- milestoneId가 null인 경우 적절한 값을 response DTO에 넣도록 수정